### PR TITLE
Clarify translation of "touring bike"

### DIFF
--- a/app/languages/de-DE.json
+++ b/app/languages/de-DE.json
@@ -70,7 +70,7 @@
     "Shortest": "Kürzeste", 
     "BICYCLENORMAL": "Normal", 
     "BICYCLESAFEST": "Sichere Route", 
-    "BICYCLETOUR": "Tourenrad", 
+    "BICYCLETOUR": "Trekkingrad", 
     "BICYCLEMTB": "Mountainbike", 
     "BICYCLERACING": "Rennrad", 
     "BICYCLEELECTRO": "E-Bike", 


### PR DESCRIPTION
Some bicycle types are not that well defined in German. I guess "Tourenrad" is quite ambiguous understood amonf different people, but according to the German Wikipedia entry it refers more to a city bike. The equivalent to a touring bicycle would be a "Reiserad" which itself is a more stable version of a "Trekkingrad".
As a "Trekkingrad" is also quite robust and usable on not-so-well paved ways I think it's appropriate to call this routing preset "Trekkingrad".