### PR TITLE
Get rid of cors use a proxy

### DIFF
--- a/Gruntfile.default.js
+++ b/Gruntfile.default.js
@@ -210,6 +210,8 @@ module.exports = function(grunt) {
                                 "/node_modules",
                                 serveStatic("./node_modules")
                             ),
+                            // MARQ24 added proxy to avoid CORS when running OWN backend via SpringBoot
+                            proxy("/ors",{ target: 'http://localhost:8082', changeOrigin: true, pathRewrite: {'^/ors/': '/' }}),
                             serveStatic("./app")
                         ];
                     }
@@ -266,13 +268,13 @@ module.exports = function(grunt) {
                     ENV: {
                         name: "local",
                         geocode:
-                            "http://localhost:8082/ors/geocode",
+                            "http://localhost:3005/ors/geocode",
                         directions:
-                            "http://localhost:8082/ors/v2/directions",
+                            "http://localhost:3005/ors/v2/directions",
                         isochrones:
-                            "http://localhost:8082/ors/isochrones",
+                            "http://localhost:3005/ors/isochrones",
                         matrix:
-                            "http://localhost:8082/ors/matrix",
+                            "http://localhost:3005/ors/matrix",
                         pois:
                             "https://api.openrouteservice.org/pois",
                         shortenlink: "https://api-ssl.bitly.com/v3/shorten",

--- a/Gruntfile.default.js
+++ b/Gruntfile.default.js
@@ -4,6 +4,7 @@ module.exports = function(grunt) {
         pattern: ["grunt-*", "!grunt-cli*"]
     });
     var modRewrite = require("connect-modrewrite");
+    var proxy = require("http-proxy-middleware");
     var serveStatic = require("serve-static");
     grunt.initConfig({
         copy: {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "grunt-traceur": "git+https://github.com/aaronfrost/grunt-traceur.git",
     "grunt-usemin": "git+https://github.com/TheGreatRefrigerator/grunt-usemin.git",
     "grunt-version": "^1.3.1",
+    "http-proxy-middleware": "^0.20.0",
     "lite-server": "^2.5.4",
     "load-grunt-tasks": "^3.5.2",
     "serve-static": "^1.13.2",


### PR DESCRIPTION
When you use the ors backend via Spring Boot the CORS filter from the web.xml does not have any effect - this mean that you can't use the backend locally (since the browser will intercept the POST request (e.g to a route)...

In order to solve this I have added a proxy server that will redirect all calls to /ors/* (on port 3005) to the real backend running on the port 8028...

So you can use the grunt target ors_local with a backend running on your same localhost