### PR TITLE
TurnInstructions in TCX

### DIFF
--- a/app/infrastructure/ors-importexport-service.js
+++ b/app/infrastructure/ors-importexport-service.js
@@ -5,6 +5,7 @@ angular
  **/ .factory("orsExportFactory", [
     "FileSaver",
     "Blob",
+    "$translate",
     "orsNamespaces",
     "orsRequestService",
     "orsSettingsFactory",
@@ -13,6 +14,7 @@ angular
     (
       FileSaver,
       Blob,
+      $translate,
       orsNamespaces,
       orsRequestService,
       orsSettingsFactory,
@@ -132,7 +134,8 @@ angular
             },
             Intensity: "Active"
           },
-          Track: { Trackpoint: [] }
+          Track: { Trackpoint: [] },
+          CoursePoint: []
         };
         let duration;
         for (const data of pointInformation) {
@@ -164,6 +167,109 @@ angular
           }
         }
         courseObj.Lap.TotalTimeSeconds = duration.toFixed(1);
+
+        // adding now the navigation info...
+        let turnInstructions =
+            orsRouteService.data.features[orsRouteService.getCurrentRouteIdx()]
+                .properties.segments;
+
+        // for the timing we need to sum up the distance of the steps...
+        // (to be able to calculate the time of the 'CoursePoint')
+        let totalDistance = 0;
+        let segmentCount = 0;
+        for (const segment of turnInstructions) {
+          for (const step of segment.steps) {
+            totalDistance = totalDistance + step.distance;
+            duration = totalDistance / speedInMPerS;
+            const seconds = duration.toFixed(3) || 0;
+            const milliSeconds = seconds.split(".")[1] || 0;
+            let durationDate = new Date(
+                2010,
+                0,
+                1,
+                12,
+                0,
+                seconds,
+                milliSeconds
+            );
+
+            let alternativeName;
+            let pointType;
+            // see org.heigit.ors.routing.instructions.InstructionType
+            switch (step.type) {
+              case 0:
+              case 2:
+              case 4:
+              case 12:
+                pointType = "Left";
+                break;
+
+              case 1:
+              case 3:
+              case 5:
+              case 13:
+                pointType = "Right";
+                break;
+
+              case 6:
+                // Continue...
+                pointType = "Straight";
+                break;
+
+              case 7:
+                pointType = "Right"; // not valid in LeftSide Traffic countries...
+                alternativeName =
+                    $translate.instant("TURN_INFO_RDB_EXIT") +
+                    " " +
+                    step.exit_number;
+                break;
+
+              case 9:
+                pointType = "Generic";
+                alternativeName = $translate.instant("TURN_INFO_UTURN");
+                break;
+
+              case 10: // finish
+              case 11: // depart
+                if (
+                    (turnType == 11 && segmentCount == 0) ||
+                    (turnType == 10 && segmentCount == turnInstructions.length)
+                ) {
+                  pointType = "Generic";
+                }
+                // start and end...
+                break;
+
+              default:
+                break;
+            }
+
+            if (pointType != undefined) {
+              // the index of the coordinate of the "step" start...
+              let coordIndex = step.way_points[0];
+
+              // get rid of the possible present HTML tags...
+              let inst = step.instruction.replace(/<[^>]+>/g, "").trim();
+
+              // adding the Turn-Instructions...
+              let coursePointObj = {
+                Name:
+                    alternativeName != undefined
+                        ? alternativeName
+                        : inst.substr(0, 10).trim(),
+                Time: durationDate.toISOString(),
+                Position: {
+                  LatitudeDegrees: pointInformation[coordIndex].coords[0],
+                  LongitudeDegrees: pointInformation[coordIndex].coords[1]
+                },
+                PointType: pointType,
+                Notes: inst
+              };
+              courseObj.CoursePoint.push(coursePointObj);
+            }
+          }
+          segmentCount++;
+        }
         tcx.TrainingCenterDatabase.Courses.Course.push(courseObj);
 
         JXON.config({ attrPrefix: "@" });

--- a/app/languages/de-DE.json
+++ b/app/languages/de-DE.json
@@ -231,5 +231,7 @@
     "ROUNDTRIP_NEXT": "Nächster Rundweg",
     "ROUNDTRIP": "Rundweg (experimentell)",
     "ROUNDTRIP_DO": "Rundweg generieren",
-    "PACE_SPEED_INKMH": "Pace in km/h"
+    "PACE_SPEED_INKMH": "Pace in km/h",
+    "TURN_INFO_RDB_EXIT": "Ausfahrt",
+    "TURN_INFO_UTURN": "Kehrtwende"
 }

--- a/app/languages/en-GB.json
+++ b/app/languages/en-GB.json
@@ -231,5 +231,7 @@
     "ROUNDTRIP_NEXT": "Next round trip",
     "ROUNDTRIP": "Round trip (experimental)",
     "ROUNDTRIP_DO": "Do round trip",
-    "PACE_SPEED_INKMH": "Pace in km/h"
+    "PACE_SPEED_INKMH": "Pace in km/h",
+    "TURN_INFO_RDB_EXIT": "Exit",
+    "TURN_INFO_UTURN": "U-Turn"
 }

--- a/app/languages/en-US.json
+++ b/app/languages/en-US.json
@@ -231,5 +231,7 @@
     "ROUNDTRIP_NEXT": "Next round trip",
     "ROUNDTRIP": "Round trip (experimental)",
     "ROUNDTRIP_DO": "Do round trip",
-    "PACE_SPEED_INKMH": "Pace in km/h"
+    "PACE_SPEED_INKMH": "Pace in km/h",
+    "TURN_INFO_RDB_EXIT": "Exit",
+    "TURN_INFO_UTURN": "U-Turn"
 }

--- a/app/languages/es-ES.json
+++ b/app/languages/es-ES.json
@@ -230,5 +230,7 @@
     "ROUNDTRIP_NEXT": "Next round trip",
     "ROUNDTRIP": "Round trip (experimental)",
     "ROUNDTRIP_DO": "Do round trip",
-    "PACE_SPEED_INKMH": "Pace in km/h"
+    "PACE_SPEED_INKMH": "Pace in km/h",
+    "TURN_INFO_RDB_EXIT": "Exit",
+    "TURN_INFO_UTURN": "U-Turn"
 }

--- a/app/languages/fr-FR.json
+++ b/app/languages/fr-FR.json
@@ -230,5 +230,7 @@
     "ROUNDTRIP_NEXT": "Next round trip",
     "ROUNDTRIP": "Round trip (experimental)",
     "ROUNDTRIP_DO": "Do round trip",
-    "PACE_SPEED_INKMH": "Pace in km/h"
+    "PACE_SPEED_INKMH": "Pace in km/h",
+    "TURN_INFO_RDB_EXIT": "Exit",
+    "TURN_INFO_UTURN": "U-Turn"
 }

--- a/app/languages/hu-HU.json
+++ b/app/languages/hu-HU.json
@@ -231,5 +231,7 @@
     "ROUNDTRIP_NEXT": "Next round trip",
     "ROUNDTRIP": "Round trip (experimental)",
     "ROUNDTRIP_DO": "Do round trip",
-    "PACE_SPEED_INKMH": "Pace in km/h"
+    "PACE_SPEED_INKMH": "Pace in km/h",
+    "TURN_INFO_RDB_EXIT": "Exit",
+    "TURN_INFO_UTURN": "U-Turn"
 }

--- a/app/languages/id-ID.json
+++ b/app/languages/id-ID.json
@@ -231,5 +231,7 @@
     "ROUNDTRIP_NEXT": "Next round trip",
     "ROUNDTRIP": "Round trip (experimental)",
     "ROUNDTRIP_DO": "Do round trip",
-    "PACE_SPEED_INKMH": "Pace in km/h"
+    "PACE_SPEED_INKMH": "Pace in km/h",
+    "TURN_INFO_RDB_EXIT": "Exit",
+    "TURN_INFO_UTURN": "U-Turn"
 }

--- a/app/languages/it-IT.json
+++ b/app/languages/it-IT.json
@@ -231,5 +231,7 @@
     "ROUNDTRIP_NEXT": "Next round trip",
     "ROUNDTRIP": "Round trip (experimental)",
     "ROUNDTRIP_DO": "Do round trip",
-    "PACE_SPEED_INKMH": "Pace in km/h"
+    "PACE_SPEED_INKMH": "Pace in km/h",
+    "TURN_INFO_RDB_EXIT": "Exit",
+    "TURN_INFO_UTURN": "U-Turn"
 }

--- a/app/languages/pl-PL.json
+++ b/app/languages/pl-PL.json
@@ -230,5 +230,7 @@
     "ROUNDTRIP_NEXT": "Next round trip",
     "ROUNDTRIP": "Round trip (experimental)",
     "ROUNDTRIP_DO": "Do round trip",
-    "PACE_SPEED_INKMH": "Pace in km/h"
+    "PACE_SPEED_INKMH": "Pace in km/h",
+    "TURN_INFO_RDB_EXIT": "Exit",
+    "TURN_INFO_UTURN": "U-Turn"
 }

--- a/app/languages/pt-PT.json
+++ b/app/languages/pt-PT.json
@@ -230,5 +230,7 @@
     "ROUNDTRIP_NEXT": "Next round trip",
     "ROUNDTRIP": "Round trip (experimental)",
     "ROUNDTRIP_DO": "Do round trip",
-    "PACE_SPEED_INKMH": "Pace in km/h"
+    "PACE_SPEED_INKMH": "Pace in km/h",
+    "TURN_INFO_RDB_EXIT": "Exit",
+    "TURN_INFO_UTURN": "U-Turn"
 }

--- a/app/languages/ru-RU.json
+++ b/app/languages/ru-RU.json
@@ -231,5 +231,7 @@
     "ROUNDTRIP_NEXT": "Next round trip",
     "ROUNDTRIP": "Round trip (experimental)",
     "ROUNDTRIP_DO": "Do round trip",
-    "PACE_SPEED_INKMH": "Pace in km/h"
+    "PACE_SPEED_INKMH": "Pace in km/h",
+    "TURN_INFO_RDB_EXIT": "Exit",
+    "TURN_INFO_UTURN": "U-Turn"
 }

--- a/app/languages/zh-CN.json
+++ b/app/languages/zh-CN.json
@@ -230,5 +230,7 @@
     "ROUNDTRIP_NEXT": "Next round trip",
     "ROUNDTRIP": "Round trip (experimental)",
     "ROUNDTRIP_DO": "Do round trip",
-    "PACE_SPEED_INKMH": "Pace in km/h"
+    "PACE_SPEED_INKMH": "Pace in km/h",
+    "TURN_INFO_RDB_EXIT": "Exit",
+    "TURN_INFO_UTURN": "U-Turn"
 }


### PR DESCRIPTION
adding <CoursePoint> Elements to the TCX export so that suporting devices can provide instructions - with the limitation that only LEFT|RIGHT|STAIGHT is supported. Also no support for roundabout exits (will cause issues on left side traffic countries)

Just was made aware yesterday, that TCX also support some sort of simple TurnInstructions via the `<CoursePoint>` Element - so I have added some code to support this... 

But there is no need for a instant/urgent release