### PR TITLE
fix #335

### DIFF
--- a/app/infrastructure/ors-importexport-service.js
+++ b/app/infrastructure/ors-importexport-service.js
@@ -45,7 +45,7 @@ angular
         let payload = orsUtilsService.routingPayload(settings, userOptions);
         payload.geometry_format = "gpx";
         if (!options.instructions) payload.instructions = false;
-        const request = orsRouteService.fetchRoute(payload);
+        const request = orsUtilsService.createRequest("directions", payload);
         orsRouteService.routingRequests.requests.push(request);
         request.promise.then(
           function(response) {


### PR DESCRIPTION
just switched to the new method as shown in 'Migrate isochrone requests to V2 endpoint'