### PR TITLE
Distance markers

### DIFF
--- a/app/components/ors-map/ors-map.js
+++ b/app/components/ors-map/ors-map.js
@@ -290,12 +290,17 @@ angular.module("orsApp").directive("orsMap", () => {
           if (setting === "distanceMarkers") {
             // get Leaflet route object
             let lines = $scope.mapModel.geofeatures.layerRouteLines._layers;
-            let route = lines[Object.keys(lines)[0]];
 
             if (options.distanceMarkers === true) {
-              route.addDistanceMarkers();
+              Object.values(lines).forEach(route => {
+                if (route.options.distanceMarkers.cssClass)
+                  route.addDistanceMarkers();
+              });
             } else {
-              route.removeDistanceMarkers();
+              Object.values(lines).forEach(route => {
+                if (route.options.distanceMarkers.cssClass)
+                  route.removeDistanceMarkers();
+              });
             }
           }
         });

--- a/app/components/ors-map/ors-map.js
+++ b/app/components/ors-map/ors-map.js
@@ -1115,6 +1115,7 @@ angular.module("orsApp").directive("orsMap", () => {
          */
         $scope.addFeatures = actionPackage => {
           const isDistanceMarkers =
+            actionPackage.layerCode == "layerRouteLines" &&
             orsSettingsFactory.getUserOptions().distanceMarkers === true;
           let polyLine = L.polyline(actionPackage.geometry, {
             index:


### PR DESCRIPTION
Enabling distance markers in the settings has two issues:

1. Distance markers are shown on all lines.
- For uploaded tracks, markers of the preview are indistinguishable from track markers and cannot be removed afterwards.
- When showing information on the map, such as road surfaces, the segments also add distance markers if the same color is added for more than 1 km.
2. Enabling or disabling distance markers only updates the first route.
- When the distance marker checkbox is changed, distance markers on the first route follow the setting. However, alternative routes don't change.

Proposed solutions:
1. Only show distance markers on routes, not on previews and informative colouring.
2. Toggle distance markers of all layers for which they are configured (i.e. a css class is set) when changing the setting.