### PR TITLE
Use npm version of clipboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ RELEASING:
 8. Add version to docker-compose.yml (grunt version always adds 1 on top the current version ...)
  -->
 
+## [Unreleased]
+
+### Changed
+- clipboard.js from bower to npm
+
+### Fixed
+- broken build due to clipboard.js ([#359](https://github.com/GIScience/openrouteservice-app/issues/359))
+
 ## [v0.7.0] - 2021-02-03
 
 ### Added

--- a/app/index.html
+++ b/app/index.html
@@ -102,7 +102,7 @@
 <script src="bower_components/angular-sanitize/angular-sanitize.js"></script>
 <script src="bower_components/angular-translate/angular-translate.js"></script>
 <script src="bower_components/ng-focus-if/focusIf.min.js"></script>
-<script src="bower_components/clipboard/dist/clipboard.min.js"></script>
+<script src="node_modules/clipboard/dist/clipboard.min.js"></script>
 <script src="bower_components/ngclipboard/dist/ngclipboard.min.js"></script>
 <script src="bower_components/angular-translate-loader-static-files/angular-translate-loader-static-files.js"></script>
 <script src="node_modules/@angular/router/angular1/angular_1_router.js"></script>

--- a/bower.json
+++ b/bower.json
@@ -30,8 +30,7 @@
     "leaflet.locatecontrol": "^0.62.0",
     "leaflet-distance-markers": "https://github.com/adoroszlai/leaflet-distance-markers.git",
     "ng-focus-if": "^1.0.7",
-    "ngclipboard": "^2.0.0",
-    "clipboard": "^2.0.0"
+    "ngclipboard": "^2.0.0"
   },
   "resolutions": {
     "angular": "~1.5.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1546,6 +1546,17 @@
         "glob": "^7.1.1"
       }
     },
+    "clipboard": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
+      "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
+      "dev": true,
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -2214,6 +2225,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "dev": true
     },
     "depd": {
       "version": "2.0.0",
@@ -3101,6 +3118,15 @@
         "glob": "~7.1.1",
         "lodash": "~4.17.10",
         "minimatch": "~3.0.2"
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "dev": true,
+      "requires": {
+        "delegate": "^3.1.2"
       }
     },
     "graceful-fs": {
@@ -6210,6 +6236,12 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "dev": true
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -7374,6 +7406,12 @@
       "requires": {
         "process": "~0.11.0"
       }
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "dev": true
     },
     "tiny-lr": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "bower": "^1.8.8",
+    "clipboard": "^2.0.8",
     "connect-modrewrite": "^0.10.2",
     "d3-scale-chromatic": "^1.5.0",
     "grunt-angular-templates": "^1.2.0",
@@ -63,8 +64,8 @@
     "grunt-traceur": "git+https://github.com/aaronfrost/grunt-traceur.git",
     "grunt-usemin": "git+https://github.com/TheGreatRefrigerator/grunt-usemin.git",
     "grunt-version": "^1.3.2",
-    "lite-server": "^2.5.4",
     "http-proxy-middleware": "0.20.0",
+    "lite-server": "^2.5.4",
     "load-grunt-tasks": "^3.5.2",
     "serve-static": "^1.14.1",
     "time-grunt": "^1.4.0",


### PR DESCRIPTION
clipboard 2.0.6 introduced some => functions into dist code.
A fix was introduced, but only available for the npm version
due to a missing update of the version number in the bower.json file.

This broke the build as uglifyjs can't parse => functions.

Fixes https://github.com/GIScience/openrouteservice-app/issues/359